### PR TITLE
Update endpoints - Add LLM feedback

### DIFF
--- a/src/api/routes/identify_corner_cases.py
+++ b/src/api/routes/identify_corner_cases.py
@@ -56,14 +56,22 @@ class IdentifyCornerCasesResponse(BaseModel):
             "description": "Lista de casos esquina identificados para la historia de usuario proporcionada."
         }
     )
+    corner_cases_feedback: str = Field(
+        ...,
+        json_schema_extra={
+            "description": "Resumen de los cambios realizados por el LLM."
+        }
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "session_id": "123e4567-e89b-12d3-a456-426614174000",
                 "corner_cases": [
-                    "Intentos de inicio de sesión con contraseñas incorrectas.",
-                    "Acceso simultáneo desde múltiples dispositivos."
-                ]
+                    "1. **Intentos de Inicio de Sesión Fallidos:** El usuario ingresa una contraseña incorrecta repetidamente.",
+                    "2. **Bloqueo de Cuenta por Inactividad:** La cuenta está bloqueada después de un período de inactividad prolongada."
+                ],
+                "corner_cases_feedback": "Se incluyeron casos relacionados con autenticación de dos factores y bloqueos por inactividad según el feedback proporcionado."
             }
         }
     )
@@ -87,7 +95,7 @@ async def identify_corner_cases(request: IdentifyCornerCasesRequest):
         session_id = request.session_id or llm_service.create_session()
         
         # Identificar casos esquina usando el servicio LLM
-        corner_cases = await llm_service.identify_corner_cases(
+        result = await llm_service.identify_corner_cases(
             session_id=session_id,
             refined_story=request.story,
             feedback=request.feedback
@@ -95,7 +103,8 @@ async def identify_corner_cases(request: IdentifyCornerCasesRequest):
         
         return {
             "session_id": session_id,
-            "corner_cases": corner_cases
+            "corner_cases": result['corner_cases'],
+            "corner_cases_feedback": result['corner_cases_feedback']
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) 

--- a/src/api/routes/propose_testing_strategy.py
+++ b/src/api/routes/propose_testing_strategy.py
@@ -70,14 +70,23 @@ class ProposeTestingStrategyResponse(BaseModel):
             "description": "Lista de estrategias de testing propuestas basadas en la historia refinada y los casos esquina."
         }
     )
+    testing_feedback: str = Field(
+        ...,
+        json_schema_extra={
+            "description": "Resumen de los cambios realizados por el LLM."
+        }
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
+                "session_id": "123e4567-e89b-12d3-a456-426614174000",
                 "testing_strategies": [
-                    "Pruebas de autenticación con credenciales válidas e inválidas.",
-                    "Pruebas de concurrencia para verificar el manejo de múltiples sesiones."
-                ]
+                    "1. **Pruebas de Carga:** Realizar pruebas bajo carga para asegurar que el sistema maneja múltiples solicitudes de inicio de sesión simultáneas.",
+                    "2. **Pruebas de Seguridad:** Implementar pruebas para detectar y prevenir ataques de fuerza bruta.",
+                    "3. **Pruebas de Autenticación de Dos Factores:** Verificar que el 2FA funciona correctamente en diversos escenarios."
+                ],
+                "testing_feedback": "Se añadieron pruebas de rendimiento bajo carga y pruebas de seguridad según el feedback proporcionado."
             }
         }
     )
@@ -102,7 +111,7 @@ async def propose_testing_strategy(request: ProposeTestingStrategyRequest):
         session_id = request.session_id or llm_service.create_session()
         
         # Proponer estrategias usando el servicio LLM
-        testing_strategies = await llm_service.propose_testing_strategy(
+        result = await llm_service.propose_testing_strategy(
             session_id=session_id,
             refined_story=request.story,
             corner_cases=request.corner_cases,
@@ -111,7 +120,8 @@ async def propose_testing_strategy(request: ProposeTestingStrategyRequest):
         
         return {
             "session_id": session_id,
-            "testing_strategies": testing_strategies
+            "testing_strategies": result['testing_strategies'],
+            "testing_feedback": result['testing_feedback']
         }
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) 

--- a/src/llm/models.py
+++ b/src/llm/models.py
@@ -19,5 +19,8 @@ class SessionState(BaseModel):
     session_id: UUID
     current_state: ProcessState
     refined_story: str | None = None
+    refinement_feedback: Optional[str] = None
     corner_cases: list[str] | None = None
+    corner_cases_feedback: Optional[str] = None
     testing_strategies: Optional[list[str]] = None
+    testing_feedback: Optional[str] = None

--- a/src/llm/prompts/corner_case.py
+++ b/src/llm/prompts/corner_case.py
@@ -10,16 +10,24 @@ corner_case_prompt = PromptTemplate(
     Feedback del Usuario (si existe):
     {feedback}
 
-    Por favor, enumera y describe casos esquina o escenarios límite que podrían surgir al implementar esta historia de usuario, teniendo en cuenta el feedback proporcionado (si existe). Responde únicamente con la siguiente sección claramente delimitada:
+    Por favor, enumera y describe casos esquina o escenarios límite que podrían surgir al implementar esta historia de usuario, teniendo en cuenta el feedback proporcionado (si existe). Además, proporciona un resumen de los cambios o consideraciones adicionales que has realizado.
+
+    Responde únicamente con las siguientes secciones claramente delimitadas:
 
     **Casos Esquina:**
     Aquí van los casos esquina identificados.
+
+    **Análisis de Cambios:**
+    Aquí va un resumen de los cambios realizados o consideraciones adicionales.
 
     **Ejemplo de Respuesta:**
     **Casos Esquina:**
     1. **Inicio de Sesión Incorrecto:** El usuario ingresa una contraseña incorrecta más de 5 veces consecutivas.
     2. **Recuperación de Contraseña Fallida:** El sistema no envía el correo de recuperación de contraseña debido a problemas de conexión con el servidor de correo.
     3. **Acceso Concurrente:** Múltiples intentos de inicio de sesión desde diferentes ubicaciones geográficas en un corto período de tiempo.
+
+    **Análisis de Cambios:**
+    - Se añadieron escenarios relacionados con autenticación fallida y seguridad según el feedback.
     """,
     input_variables=["refined_user_story", "feedback"]
 )

--- a/src/llm/prompts/refinement.py
+++ b/src/llm/prompts/refinement.py
@@ -10,14 +10,21 @@ Historia de Usuario Original:
 Feedback del Usuario (si existe):
 {feedback}
 
-Teniendo en cuenta la historia de usuario y el feedback proporcionado (si existe), por favor, refina la historia para mejorar su claridad y completitud. Responde únicamente con la siguiente sección claramente delimitada:
+Teniendo en cuenta la historia de usuario y el feedback proporcionado (si existe), por favor, refina la historia para mejorar su claridad y completitud, y proporciona un resumen de los cambios realizados. Responde únicamente con las siguientes secciones claramente delimitadas:
 
 **Historia Refinada:**
 Aquí va la historia refinada.
 
+**Cambios Realizados:**
+Aquí va un resumen de los cambios realizados.
+
 **Ejemplo de Respuesta:**
 **Historia Refinada:**
 Como usuario registrado, quiero poder iniciar sesión en mi cuenta utilizando mi correo electrónico y contraseña para acceder a mis datos personales de manera segura.
+
+**Cambios Realizados:**
+- Se especificó el método de autenticación (correo electrónico y contraseña).
+- Se añadió el énfasis en la seguridad al acceder a datos personales.
 """,
     input_variables=["user_story", "feedback"]
 )

--- a/src/llm/prompts/testing.py
+++ b/src/llm/prompts/testing.py
@@ -2,7 +2,7 @@ from langchain.prompts import PromptTemplate
 
 testing_strategy_prompt = PromptTemplate(
     template="""
-    Eres un experto en desarrollo de software que diseña estrategias de testing para asegurar la calidad del producto.
+    Eres un ingeniero de pruebas experto que propone estrategias de testing basadas en una historia de usuario refinada y sus casos esquina.
 
     Historia de Usuario Refinada:
     {refined_user_story}
@@ -13,17 +13,26 @@ testing_strategy_prompt = PromptTemplate(
     Feedback del Usuario (si existe):
     {feedback}
 
-    Basándote en la historia de usuario refinada, los casos esquina identificados y el feedback proporcionado (si existe), por favor, propone una estrategia de testing detallada que incluya:
-    - Tipos de tests necesarios
-    - Herramientas recomendadas
-    - Pasos a seguir para asegurar una implementación exitosa
+    Teniendo en cuenta la historia, los casos esquina y el feedback, por favor:
 
-    Responde únicamente con la siguiente sección claramente delimitada:
+    1. **Proporciona estrategias de testing detalladas** para asegurar que la funcionalidad cumple con los requisitos y que los casos esquina están adecuadamente cubiertos.
+    2. **Resalta las estrategias que incorporan el feedback del usuario**, mencionando explícitamente cómo se ha considerado.
 
-    **Estrategia de Testing:**
-    Aquí va la estrategia de testing sugerida.
+    Responde únicamente con las siguientes secciones claramente delimitadas:
 
-    **Fin de Estrategia**
+    **Estrategias de Testing:**
+    Aquí van las estrategias de testing propuestas.
+
+    **Análisis de Cambios:**
+    Aquí va un resumen de cómo se ha incorporado el feedback proporcionado.
+
+    **Ejemplo de Respuesta:**
+    **Estrategias de Testing:**
+    1. **Pruebas de Carga:** Realizar pruebas bajo condiciones de estrés para asegurar que el sistema maneja múltiples solicitudes simultáneas.
+    2. **Pruebas de Seguridad Avanzada:** Implementar pruebas para detectar vulnerabilidades y asegurar la protección de datos sensibles.
+
+    **Análisis de Cambios:**
+    - Se añadieron **pruebas de estrés** y **seguridad avanzada** según el feedback proporcionado.
     """,
     input_variables=["refined_user_story", "corner_cases", "feedback"]
 )

--- a/tests/api/test_identify_corner_cases_endpoint.py
+++ b/tests/api/test_identify_corner_cases_endpoint.py
@@ -2,34 +2,36 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from src.main import app
 
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
 @pytest.mark.asyncio
 async def test_identify_corner_cases_endpoint(llm_service):
     """Test para el endpoint de identificación de casos esquina con feedback"""
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
-    
+    refined_story = "Como usuario quiero..."
     payload = {
         'story': refined_story,
-        'feedback': 'Considerar también casos de autenticación de dos factores y bloqueos de cuenta por inactividad'
+        'feedback': 'Considerar casos de autenticación de dos factores y bloqueos por inactividad'
     }
-    
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test/api") as client:
         response = await client.post("/identify_corner_cases", json=payload)
         assert response.status_code == 200, f"Se esperaba el código de estado 200, pero se obtuvo {response.status_code}"
-        
+
         response_json = response.json()
         assert "corner_cases" in response_json, "Falta la clave 'corner_cases' en la respuesta"
-        
+        assert "corner_cases_feedback" in response_json, "Falta la clave 'corner_cases_feedback' en la respuesta"
+
         corner_cases = response_json["corner_cases"]
+        corner_cases_feedback = response_json["corner_cases_feedback"]
+
         assert isinstance(corner_cases, list), "El valor de 'corner_cases' debe ser una lista"
         assert len(corner_cases) > 0, "La lista de 'corner_cases' no debe estar vacía"
-        
-        for caso in corner_cases:
-            assert isinstance(caso, str), "Cada caso esquina debe ser una cadena"
-            if caso.strip():  # Solo validar líneas no vacías
-                assert len(caso.strip()) > 0, "Los casos esquina no deben estar vacíos"
-        
+
+        assert isinstance(corner_cases_feedback, str), "El valor de 'corner_cases_feedback' debe ser una cadena"
+        assert len(corner_cases_feedback.strip()) > 0, "El valor de 'corner_cases_feedback' no debe estar vacío"
+
         # Verificar que el feedback se ha tenido en cuenta
-        assert any(["2fa" in caso.lower() or 
-                   "dos factores" in caso.lower() or 
-                   "inactividad" in caso.lower() for caso in corner_cases if caso.strip()]), \
-            "Los casos esquina deben incluir escenarios mencionados en el feedback"
+        assert any(keyword in corner_cases_feedback.lower() for keyword in ["autenticación de dos factores", "inactividad"]), \
+            "El feedback debe mencionar los cambios relacionados con el feedback proporcionado"

--- a/tests/api/test_propose_testing_strategy_endpoint.py
+++ b/tests/api/test_propose_testing_strategy_endpoint.py
@@ -2,42 +2,41 @@ import pytest
 from httpx import AsyncClient, ASGITransport
 from src.main import app
 
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
 @pytest.mark.asyncio
 async def test_propose_testing_strategy_endpoint(llm_service):
     """Test para el endpoint de propuesta de estrategias de testing con feedback"""
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
+    refined_story = "Como usuario quiero..."
     corner_cases = [
-        "1. **Nombre de Usuario/Correo electrónico no registrado:** El usuario intenta iniciar sesión con una dirección de correo electrónico o nombre de usuario que no se encuentra en la base de datos del sistema.",
-        "2. **Contraseña Incorrecta persistente:** El usuario ingresa la contraseña incorrecta más de 10 veces consecutivas, lo que bloquea temporalmente su acceso al sistema.",
-        "3. **Problemas con autenticación de dos factores (2FA):** El usuario no puede iniciar sesión porque el sistema requiere la verificación del código de autenticación 2FA, pero el dispositivo del usuario no es compatible o no tiene el código disponible.",
-        "4. **Bloqueo de cuenta por seguridad:** La cuenta del usuario está bloqueada temporalmente debido a inactividad prolongada o actividad sospechosa, lo que impide su acceso hasta que se complete el proceso de desbloqueo.",
-        "5. **Compatibilidad con navegadores antiguos:** El sistema no es compatible con ciertos navegadores antiguos o versiones obsoletas, lo que limita la funcionalidad del inicio de sesión para algunos usuarios."
+        "1. Caso esquina 1",
+        "2. Caso esquina 2"
     ]
-    
     payload = {
         'story': refined_story,
         'corner_cases': corner_cases,
-        'feedback': 'Incluir pruebas de rendimiento bajo carga y pruebas de seguridad para prevenir ataques de fuerza bruta'
+        'feedback': 'Incluir pruebas de estrés y seguridad avanzada'
     }
-    
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test/api") as client:
         response = await client.post("/propose_testing_strategy", json=payload)
         assert response.status_code == 200, f"Se esperaba el código de estado 200, pero se obtuvo {response.status_code}"
-        
+
         response_json = response.json()
         assert "testing_strategies" in response_json, "Falta la clave 'testing_strategies' en la respuesta"
-        
+        assert "testing_feedback" in response_json, "Falta la clave 'testing_feedback' en la respuesta"
+
         testing_strategies = response_json["testing_strategies"]
+        testing_feedback = response_json["testing_feedback"]
+
         assert isinstance(testing_strategies, list), "El valor de 'testing_strategies' debe ser una lista"
         assert len(testing_strategies) > 0, "La lista de 'testing_strategies' no debe estar vacía"
-        
-        for estrategia in testing_strategies:
-            assert isinstance(estrategia, str), "Cada estrategia de testing debe ser una cadena"
-            if estrategia.strip():  # Solo validar líneas no vacías
-                assert len(estrategia.strip()) > 0, "Las estrategias no deben estar vacías"
-        
+
+        assert isinstance(testing_feedback, str), "El valor de 'testing_feedback' debe ser una cadena"
+        assert len(testing_feedback.strip()) > 0, "El valor de 'testing_feedback' no debe estar vacío"
+
         # Verificar que el feedback se ha tenido en cuenta
-        assert any(["rendimiento" in estrategia.lower() or 
-                   "carga" in estrategia.lower() or 
-                   "seguridad" in estrategia.lower() for estrategia in testing_strategies if estrategia.strip()]), \
-            "Las estrategias deben incluir pruebas mencionadas en el feedback"
+        assert any(keyword in testing_feedback.lower() for keyword in ["pruebas de estrés", "seguridad avanzada"]), \
+            "El feedback debe mencionar los cambios relacionados con el feedback proporcionado"

--- a/tests/api/test_refine_story_endpoint.py
+++ b/tests/api/test_refine_story_endpoint.py
@@ -20,13 +20,24 @@ async def test_refine_story_endpoint(llm_service):
         
         response_json = response.json()
         assert "refined_story" in response_json, "Falta la clave 'refined_story' en la respuesta"
+        assert "refinement_feedback" in response_json, "Falta la clave 'refinement_feedback' en la respuesta"
         
         refined_story = response_json["refined_story"]
+        refinement_feedback = response_json["refinement_feedback"]
+
         assert isinstance(refined_story, str), "El valor de 'refined_story' debe ser una cadena"
         assert len(refined_story.strip()) > 0, "El valor de 'refined_story' no debe estar vacío"
+
+        assert isinstance(refinement_feedback, str), "El valor de 'refinement_feedback' debe ser una cadena"
+        assert len(refinement_feedback.strip()) > 0, "El valor de 'refinement_feedback' no debe estar vacío"
         
-        # Verificar que el feedback se ha tenido en cuenta
+        # Verificar que el feedback se ha tenido en cuenta en la historia refinada
         assert any(["correo" in refined_story.lower() or 
                    "email" in refined_story.lower() or 
                    "contraseña" in refined_story.lower()]), \
             "La historia refinada debe incorporar el feedback sobre el método de autenticación"
+
+        # Verificar que el feedback de refinamiento menciona los cambios realizados
+        assert any(["método de autenticación" in refinement_feedback.lower() or
+                    "datos" in refinement_feedback.lower()] ), \
+            "El feedback de refinamiento debe mencionar los cambios realizados según el feedback proporcionado"

--- a/tests/unit/test_identify_corner_cases.py
+++ b/tests/unit/test_identify_corner_cases.py
@@ -4,27 +4,34 @@ import pytest
 async def test_identify_corner_cases_without_feedback(llm_service):
     """Test para identificar casos esquina sin feedback"""
     session_id = llm_service.create_session()
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
+    refined_story = "Como usuario quiero..."
 
     result = await llm_service.identify_corner_cases(
         session_id=session_id,
         refined_story=refined_story
     )
 
-    # Verificar que se recibe una lista de casos esquina
-    assert isinstance(result, list), "El resultado debe ser una lista"
-    assert len(result) > 0, "Debe haber al menos un caso esquina identificado"
-    for caso in result:
-        assert isinstance(caso, str), "Cada caso esquina debe ser una cadena"
-        if caso.strip():  # Solo validar líneas no vacías
-            assert len(caso.strip()) > 0, "Los casos esquina no deben estar vacíos"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'corner_cases' in result, "El resultado debe contener 'corner_cases'"
+    assert 'corner_cases_feedback' in result, "El resultado debe contener 'corner_cases_feedback'"
+
+    # Verificar que los casos esquina son una lista no vacía
+    corner_cases = result['corner_cases']
+    assert isinstance(corner_cases, list), "Los casos esquina deben ser una lista"
+    assert len(corner_cases) > 0, "Debe haber al menos un caso esquina identificado"
+
+    # Verificar que el feedback es una cadena no vacía
+    corner_cases_feedback = result['corner_cases_feedback']
+    assert isinstance(corner_cases_feedback, str), "El feedback debe ser una cadena"
+    assert len(corner_cases_feedback.strip()) > 0, "El feedback no debe estar vacío"
 
 @pytest.mark.asyncio
 async def test_identify_corner_cases_with_feedback(llm_service):
     """Test para identificar casos esquina con feedback"""
     session_id = llm_service.create_session()
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
-    feedback = "Considerar también casos de autenticación de dos factores y bloqueos de cuenta por inactividad"
+    refined_story = "Como usuario quiero..."
+    feedback = "Considerar casos de autenticación de dos factores y bloqueos por inactividad"
 
     result = await llm_service.identify_corner_cases(
         session_id=session_id,
@@ -32,15 +39,19 @@ async def test_identify_corner_cases_with_feedback(llm_service):
         feedback=feedback
     )
 
-    # Verificar que se recibe una lista de casos esquina
-    assert isinstance(result, list), "El resultado debe ser una lista"
-    assert len(result) > 0, "Debe haber al menos un caso esquina identificado"
-    for caso in result:
-        assert isinstance(caso, str), "Cada caso esquina debe ser una cadena"
-        if caso.strip():  # Solo validar líneas no vacías
-            assert len(caso.strip()) > 0, "Los casos esquina no deben estar vacíos"
-    # Verificar que el feedback se ha tenido en cuenta
-    assert any(["2fa" in caso.lower() or 
-                "dos factores" in caso.lower() or 
-                "inactividad" in caso.lower() for caso in result if caso.strip()]), \
-        "Los casos esquina deben incluir escenarios mencionados en el feedback"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'corner_cases' in result, "El resultado debe contener 'corner_cases'"
+    assert 'corner_cases_feedback' in result, "El resultado debe contener 'corner_cases_feedback'"
+
+    # Verificar que los casos esquina son una lista no vacía
+    corner_cases = result['corner_cases']
+    assert isinstance(corner_cases, list), "Los casos esquina deben ser una lista"
+    assert len(corner_cases) > 0, "Debe haber al menos un caso esquina identificado"
+
+    # Verificar que el feedback es una cadena no vacía y contiene referencias al feedback proporcionado
+    corner_cases_feedback = result['corner_cases_feedback']
+    assert isinstance(corner_cases_feedback, str), "El feedback debe ser una cadena"
+    assert len(corner_cases_feedback.strip()) > 0, "El feedback no debe estar vacío"
+    assert any(keyword in corner_cases_feedback.lower() for keyword in ["autenticación de dos factores", "inactividad"]), \
+        "El feedback debe mencionar los cambios relacionados con el feedback proporcionado"

--- a/tests/unit/test_propose_testing_strategy.py
+++ b/tests/unit/test_propose_testing_strategy.py
@@ -4,11 +4,10 @@ import pytest
 async def test_propose_testing_strategy_without_feedback(llm_service):
     """Test para proponer estrategias de testing sin feedback"""
     session_id = llm_service.create_session()
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
+    refined_story = "Como usuario quiero..."
     corner_cases = [
-        "1. **Nombre de Usuario/Correo electrónico no registrado:** El usuario intenta iniciar sesión con una dirección de correo electrónico o nombre de usuario que no se encuentra en la base de datos del sistema.",
-        "2. **Contraseña Incorrecta persistente:** El usuario ingresa la contraseña incorrecta más de 10 veces consecutivas.",
-        "3. **Problemas con autenticación de dos factores (2FA):** El usuario no puede iniciar sesión porque el sistema requiere la verificación del código de autenticación 2FA."
+        "1. Caso esquina 1",
+        "2. Caso esquina 2"
     ]
 
     result = await llm_service.propose_testing_strategy(
@@ -17,24 +16,31 @@ async def test_propose_testing_strategy_without_feedback(llm_service):
         corner_cases=corner_cases
     )
 
-    # Verificar que se recibe una lista de estrategias de testing
-    assert isinstance(result, list), "El resultado debe ser una lista"
-    assert len(result) > 0, "Debe haber al menos una estrategia de testing propuesta"
-    for estrategia in result:
-        assert isinstance(estrategia, str), "Cada estrategia de testing debe ser una cadena"
-        if estrategia.strip():  # Solo validar líneas no vacías
-            assert len(estrategia.strip()) > 0, "Las estrategias no deben estar vacías"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'testing_strategies' in result, "El resultado debe contener 'testing_strategies'"
+    assert 'testing_feedback' in result, "El resultado debe contener 'testing_feedback'"
+
+    # Verificar que las estrategias son una lista no vacía
+    testing_strategies = result['testing_strategies']
+    assert isinstance(testing_strategies, list), "Las estrategias de testing deben ser una lista"
+    assert len(testing_strategies) > 0, "Debe haber al menos una estrategia de testing propuesta"
+
+    # Verificar que el feedback es una cadena no vacía
+    testing_feedback = result['testing_feedback']
+    assert isinstance(testing_feedback, str), "El feedback debe ser una cadena"
+    assert len(testing_feedback.strip()) > 0, "El feedback no debe estar vacío"
 
 @pytest.mark.asyncio
 async def test_propose_testing_strategy_with_feedback(llm_service):
     """Test para proponer estrategias de testing con feedback"""
     session_id = llm_service.create_session()
-    refined_story = "Como usuario registrado, quiero poder iniciar sesión en la plataforma mediante la combinación correcta de mi nombre de usuario o dirección de correo electrónico y contraseña, para acceder a mis perfiles, historiales de compras y otros datos personales de manera segura y eficiente."
+    refined_story = "Como usuario quiero..."
     corner_cases = [
-        "1. **Nombre de Usuario/Correo electrónico no registrado:** El usuario intenta iniciar sesión con una dirección de correo electrónico o nombre de usuario que no se encuentra en la base de datos del sistema.",
-        "2. **Contraseña Incorrecta persistente:** El usuario ingresa la contraseña incorrecta más de 10 veces consecutivas."
+        "1. Caso esquina 1",
+        "2. Caso esquina 2"
     ]
-    feedback = "Incluir pruebas de rendimiento bajo carga y pruebas de seguridad para prevenir ataques de fuerza bruta"
+    feedback = "Incluir pruebas de estrés y seguridad avanzada"
 
     result = await llm_service.propose_testing_strategy(
         session_id=session_id,
@@ -43,13 +49,19 @@ async def test_propose_testing_strategy_with_feedback(llm_service):
         feedback=feedback
     )
 
-    # Verificar que se recibe una lista de estrategias de testing
-    assert isinstance(result, list), "El resultado debe ser una lista"
-    assert len(result) > 0, "Debe haber al menos una estrategia de testing propuesta"
-    for estrategia in result:
-        assert isinstance(estrategia, str), "Cada estrategia de testing debe ser una cadena"
-        if estrategia.strip():  # Solo validar líneas no vacías
-            assert len(estrategia.strip()) > 0, "Las estrategias no deben estar vacías"
-    # Verificar que el feedback se ha tenido en cuenta
-    assert any(["rendimiento" in estrategia.lower() or "carga" in estrategia.lower() or "seguridad" in estrategia.lower() for estrategia in result]), \
-        "Las estrategias deben incluir pruebas mencionadas en el feedback"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'testing_strategies' in result, "El resultado debe contener 'testing_strategies'"
+    assert 'testing_feedback' in result, "El resultado debe contener 'testing_feedback'"
+
+    # Verificar que las estrategias son una lista no vacía
+    testing_strategies = result['testing_strategies']
+    assert isinstance(testing_strategies, list), "Las estrategias de testing deben ser una lista"
+    assert len(testing_strategies) > 0, "Debe haber al menos una estrategia de testing propuesta"
+
+    # Verificar que el feedback es una cadena no vacía y contiene referencias al feedback proporcionado
+    testing_feedback = result['testing_feedback']
+    assert isinstance(testing_feedback, str), "El feedback debe ser una cadena"
+    assert len(testing_feedback.strip()) > 0, "El feedback no debe estar vacío"
+    assert any(keyword in testing_feedback.lower() for keyword in ["pruebas de estrés", "seguridad avanzada"]), \
+        "El feedback debe mencionar los cambios relacionados con el feedback proporcionado"

--- a/tests/unit/test_refine_story.py
+++ b/tests/unit/test_refine_story.py
@@ -8,19 +8,27 @@ async def test_refine_story_without_feedback(llm_service):
     Como usuario quiero poder iniciar sesión 
     para acceder a mi cuenta personal
     """
+
     result = await llm_service.refine_story(
         session_id=session_id,
         user_story=user_story
     )
 
-    # Verificar que se recibió una cadena refinada
-    assert isinstance(result, str), "El resultado debe ser una cadena"
-    assert len(result.strip()) > 0, "El resultado no debe estar vacío"
-    assert "Como usuario" in result, "La historia refinada debe mantener el formato de historia de usuario"
-    # Verificar que el feedback se ha tenido en cuenta (solo en líneas no vacías)
-    assert any(["correo" in line.lower() or "email" in line.lower() or "contraseña" in line.lower() 
-               for line in result.split('\n') if line.strip()]), \
-        "La historia refinada debe incorporar el feedback sobre el método de autenticación"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'refined_story' in result, "El resultado debe contener 'refined_story'"
+    assert 'refinement_feedback' in result, "El resultado debe contener 'refinement_feedback'"
+    
+    # Verificar que la historia refinada es una cadena no vacía
+    refined_story = result['refined_story']
+    assert isinstance(refined_story, str), "La historia refinada debe ser una cadena"
+    assert len(refined_story.strip()) > 0, "La historia refinada no debe estar vacía"
+    assert "Como usuario" in refined_story, "La historia refinada debe mantener el formato de historia de usuario"
+    
+    # Verificar que el feedback es una cadena no vacía
+    refinement_feedback = result['refinement_feedback']
+    assert isinstance(refinement_feedback, str), "El feedback de refinamiento debe ser una cadena"
+    assert len(refinement_feedback.strip()) > 0, "El feedback de refinamiento no debe estar vacío"
 
 @pytest.mark.asyncio
 async def test_refine_story_with_feedback(llm_service):
@@ -38,10 +46,24 @@ async def test_refine_story_with_feedback(llm_service):
         feedback=feedback
     )
 
-    # Verificar que se recibió una cadena refinada
-    assert isinstance(result, str), "El resultado debe ser una cadena"
-    assert len(result.strip()) > 0, "El resultado no debe estar vacío"
-    assert "Como usuario" in result, "La historia refinada debe mantener el formato de historia de usuario"
+    # Verificar que se recibió un diccionario con las claves esperadas
+    assert isinstance(result, dict), "El resultado debe ser un diccionario"
+    assert 'refined_story' in result, "El resultado debe contener 'refined_story'"
+    assert 'refinement_feedback' in result, "El resultado debe contener 'refinement_feedback'"
+
+    # Verificar que la historia refinada es una cadena no vacía
+    refined_story = result['refined_story']
+    assert isinstance(refined_story, str), "La historia refinada debe ser una cadena"
+    assert len(refined_story.strip()) > 0, "La historia refinada no debe estar vacía"
+    assert "Como usuario" in refined_story, "La historia refinada debe mantener el formato de historia de usuario"
     assert any(["correo" in line.lower() or "email" in line.lower() or "contraseña" in line.lower() 
-               for line in result.split('\n') if line.strip()]), \
+               for line in refined_story.split('\n') if line.strip()]), \
         "La historia refinada debe incorporar el feedback sobre el método de autenticación"
+
+    # Verificar que el feedback de refinamiento es una cadena no vacía
+    refinement_feedback = result['refinement_feedback']
+    assert isinstance(refinement_feedback, str), "El feedback de refinamiento debe ser una cadena"
+    assert len(refinement_feedback.strip()) > 0, "El feedback de refinamiento no debe estar vacío"
+    assert any(["método de autenticación" in refinement_feedback.lower() or
+                "datos" in refinement_feedback.lower()] ), \
+        "El feedback de refinamiento debe mencionar los cambios realizados según el feedback proporcionado"


### PR DESCRIPTION
This pull request introduces several enhancements to the API routes and the LLM service, focusing on incorporating feedback summaries and refining the structure of responses. The most important changes include adding feedback fields to response models, updating the LLM service to handle multiple sections in responses, and refining the prompts used for the LLM.

### Enhancements to API Responses:
* Added `corner_cases_feedback` field to `IdentifyCornerCasesResponse` to include a summary of changes made by the LLM. (`src/api/routes/identify_corner_cases.py`)
* Added `testing_feedback` field to `ProposeTestingStrategyResponse` to include a summary of changes made by the LLM. (`src/api/routes/propose_testing_strategy.py`)
* Added `refinement_feedback` field to `RefineStoryResponse` to include a summary of changes made by the LLM. (`src/api/routes/refine_story.py`)

### Updates to LLM Service:
* Modified `_process_step` to handle multiple sections in the response and update session state with feedback summaries. (`src/llm/service.py`)
* Updated `refine_story`, `identify_corner_cases`, and `propose_testing_strategy` methods to process and return feedback summaries. (`src/llm/service.py`)

### Refinements to Prompts:
* Updated prompts for `corner_case`, `refinement`, and `testing` to include sections for feedback summaries. (`src/llm/prompts/corner_case.py`, `src/llm/prompts/refinement.py`, `src/llm/prompts/testing.py`) [[1]](diffhunk://#diff-428e7f35d35f393dd667e315d7cce9015aca8ccdc34aed2ab2960c45f954613cL13-R30) [[2]](diffhunk://#diff-838cdab22d26f3bc97f78590aca741ff89923927c8efb8449e0d1dd746e9d5d6L13-R27) [[3]](diffhunk://#diff-9130a3a04ed85cdb81c552fa77f99a3241ee616ba313af3bce574da57eaf7e19L5-R5)

These changes enhance the clarity and completeness of the responses generated by the LLM, ensuring that feedback is explicitly addressed and summarized.